### PR TITLE
fix wrong link

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@
 
 ### LiteLoaderBDS
 - [官方文档](https://docs.litebds.com/)
-- [官方论坛](https://bbs.litebds.com/)
+- [官方论坛](https://bbs.liteldev.com/)
 - [官方仓库](https://github.com/LiteLDev/LiteLoaderBDSv2)
 
 ### 其他资源


### PR DESCRIPTION
https://bbs.litebds.com/ 是错误的链接，无法访问。
正确的，可以访问的链接是 https://bbs.liteldev.com/